### PR TITLE
Customisable URI Builder

### DIFF
--- a/slack_org_protocol.user.js
+++ b/slack_org_protocol.user.js
@@ -13,6 +13,9 @@
 
 var observing = false;
 
+// Override this variable to build your own org-protocol URI
+var orgProtocolURIBuilder = (url, title, body) => "org-protocol://capture?url=" + url + "&title=" + title + "&body=" + body;
+
 // Function to open URIs in either a web browser or in Slack Desktop.
 function crossPlatformOpen(uri) {
     // If we're in an electron environment, use open();
@@ -96,11 +99,12 @@ function insertButton() {
 }
 
 function createCaptureURI(sender, message, link) {
-  // new style
-  const encoded_url = encodeURIComponent(link);
-  const escaped_title = escapeIt(link);
-  const escaped_message = escapeIt(sender + ": " + message);
-  return "org-protocol://capture?url=" + encoded_url + "&title=" + escaped_title + "&body=" + escaped_message;
+  // Build the URI string
+  return orgProtocolURIBuilder(
+      encodeURIComponent(link), 
+      escapeIt(link), 
+      escapeIt(sender + ": " + message)
+  );
 }
 
 // From https://github.com/sprig/org-capture-extension/blob/3911377933619a24562730dc8b353424f8809d9e/capture.js#L87


### PR DESCRIPTION
Hi there,

Until now I've been using a patch to override the `createCaptureURI` function to produce URIs that work with my personal org-mode configuration. Because the possibilities for what others might want to do are rather vast, I thought the simplest and laziest way to remove the need for my patch was to move the URI creation logic into a function and expose it as a variable that can be overridden.

This PR extracts the URI creation part into an arrow function, allowing the function contents to be overridden later by redefining the variable.

In my case, I use the following function:

``` javascript
var orgProtocolURIBuilder = (url, title, body) => {
    return "org-protocol://capture?template=p&url=" + url + "&title=" + title + "&body=" + body;
};
```

You can verify it's overriding correctly by putting an `alert('hello world');` in the function.